### PR TITLE
moved height out of time slot

### DIFF
--- a/client/src/components/Calendar/TimeUnit.tsx
+++ b/client/src/components/Calendar/TimeUnit.tsx
@@ -6,6 +6,7 @@ import { Dayjs } from "dayjs";
 
 interface TimeUnitComponent extends TimeUnitProps {
   toggleTimeUnit: (unitTime: Dayjs) => void;
+  height: number;
 }
 
 const TimeUnit = ({

--- a/client/src/hooks/useCalendarContainer.ts
+++ b/client/src/hooks/useCalendarContainer.ts
@@ -1,4 +1,4 @@
-import {  useState } from "react"
+import {  useEffect, useState } from "react"
 
 import { DayProps } from "../interfaces/DayProps";
 import dayjs, { Dayjs } from "dayjs";
@@ -18,7 +18,12 @@ export const getCalendarContainerHeight = () : number => {
 }
 
 const useCalendarContainer = () : useCalendarContainerReturnProps => {
+
     const [days, setDays] = useState<DayProps[] | undefined>(undefined);
+
+    useEffect(() => {
+        console.log(days);
+    },[days])
 
     const packageDays = () : DayProps[] => {
     const packagedDays: DayProps[] = days!.map((day) => ({
@@ -80,11 +85,9 @@ const useCalendarContainer = () : useCalendarContainerReturnProps => {
     const initializeTimeUnits = (date : Dayjs) : TimeUnitProps[] => {
         let newUnits : TimeUnitProps[] = [];
         const numTimeUnits = 13;
-        const timeUnitHeight = getCalendarContainerHeight() / numTimeUnits;
         for(let i = 0; i < numTimeUnits; ++i) {
             const timeUnit : TimeUnitProps = {
                 time : date,
-                height : timeUnitHeight,
                 available : false,
             }
             newUnits.push(timeUnit);

--- a/client/src/hooks/useScheduleTasks.ts
+++ b/client/src/hooks/useScheduleTasks.ts
@@ -19,8 +19,9 @@ const useScheduleTasks = ({packageDays, getTaskList} : useScheduleTasksProps) : 
         const taskList = getTaskList()
         const requestParams = buildScheduleRequestParams(packagedDays, taskList);
         const requestBody = buildRequestBody(requestParams);
+        console.log(requestBody)
+        // @ts-ignore
         const response = await sendJsonRequest(`${SERVER_URL}/`,requestBody);
-        console.log(response);
     }
 
     const buildScheduleRequestParams = (packagedDays : DayProps[], taskList : TaskListItem[]) => {

--- a/client/src/interfaces/TimeUnitProps.tsx
+++ b/client/src/interfaces/TimeUnitProps.tsx
@@ -1,7 +1,6 @@
 import { Dayjs } from "dayjs";
 
 export interface TimeUnitProps {
-  height: number;
   time: Dayjs;
   available: boolean;
 }


### PR DESCRIPTION
Moved the height prop out of TimeUnitProps and into TimeUnitComponent interface since there is no reason to send the height of the component to the backend for task scheduling