### PR TITLE
resolved minor bug

### DIFF
--- a/server/src/models/TaskScheduler.js
+++ b/server/src/models/TaskScheduler.js
@@ -100,7 +100,7 @@ class TaskScheduler {
   }
 
   #isValidDeadline(relativeDeadline, totalTaskTime) {
-    return totalTaskTime < relativeDeadline;
+    return totalTaskTime <= relativeDeadline;
   }
 
   #getTotalTaskTime(deadlineList) {


### PR DESCRIPTION
Previously, the TaskScheduler was checking if the ``totalTaskTIme`` for a given task was strictly less than the ``relativeDeadline``. This was causing a bug for what I call "just in time" tasks. A just in time task is one that can be complete exactly when is needs to be. For example, if task x is due at 4:00PM and the last time block in which it is scheduled is 3-4PM, then it's just in time. To fix this, I simply edited the check to ensure that ``totalTaskTime`` is less than or equal to the ``relativeDeadline``.