### PR TITLE
fixed react key prop error

### DIFF
--- a/client/src/components/Calendar/DateContainer.tsx
+++ b/client/src/components/Calendar/DateContainer.tsx
@@ -26,6 +26,7 @@ const DateContainer = ({
       >
         {day.timeSlots.map((value, _index) => (
           <TimeUnit
+            key={`TimeUnit-${value.time.toISOString()}`}
             toggleTimeUnit={toggleTimeUnit}
             available={value.available}
             height={heightIn}


### PR DESCRIPTION
I made the mistake of not having a key prop on the TimeUnits that are mapped inside the ``DateContainer.tsx`` component. This was causing an annoying console error. I simply added a key prop to these mapped components to fix this