### PR TITLE
text renders properly when task widget

### DIFF
--- a/client/src/components/Calendar/TimeUnit.tsx
+++ b/client/src/components/Calendar/TimeUnit.tsx
@@ -4,6 +4,7 @@ import "../../styles/TimeUnit.css";
 import { TimeUnitProps } from "../../interfaces/TimeUnitProps";
 import { Dayjs } from "dayjs";
 import TaskChip from "./TaskChip";
+import { useEffect } from "react";
 
 interface TimeUnitComponent extends TimeUnitProps {
   toggleTimeUnit: (unitTime: Dayjs) => void;
@@ -19,6 +20,10 @@ const TimeUnit = ({
   mode,
   taskChip,
 }: TimeUnitComponent) => {
+  useEffect(() => {
+    console.log(taskChip == undefined || mode == "Edit");
+  }, []);
+
   return (
     <Box
       className="time-unit"
@@ -28,11 +33,10 @@ const TimeUnit = ({
       date-testid="time-unit"
       onClick={() => {
         mode == "Edit" ? toggleTimeUnit(time) : {};
-        mode == "Edit" ? toggleTimeUnit(time) : {};
       }}
       height={height}
     >
-      {taskChip == undefined && (
+      {(taskChip == undefined || mode == "Edit") && (
         <Typography
           color={available ? "black" : "#C0B9B2"}
           className="time-unit-typography"


### PR DESCRIPTION
After the rather messy merge regarding the two divergent branches I noticed that when a task is scheduled for a certain time slot, the text inside that slot would vanish when viewing the calendar in ``EditMode``. As this is certainly not intended, I simply made an addition to the 'if' statement that dictates if the text is rendered or not.