### PR TITLE
task name displayed inside chip

### DIFF
--- a/client/src/components/Calendar/TaskChip.tsx
+++ b/client/src/components/Calendar/TaskChip.tsx
@@ -6,7 +6,7 @@ const TaskChip = ({ title }: TaskChipProps) => {
   return (
     <Tooltip arrow placement="top" title={title}>
       <Paper className="task-chip-container">
-        <Typography>{"Task"}</Typography>
+        <Typography className="task-chip-text">{title}</Typography>
       </Paper>
     </Tooltip>
   );

--- a/client/src/styles/TaskChip.css
+++ b/client/src/styles/TaskChip.css
@@ -6,6 +6,11 @@
     justify-content: center;
     align-items: center;
     background-color: var(--accent-main) !important;
-    white-space: normal;
- 
+    overflow: hidden;
+}
+
+.task-chip-text {
+    font-size: 12px !important;
+    white-space: nowrap;
+    overflow-x: scroll;
 }


### PR DESCRIPTION
### Summary 
************
The text inside the TaskChip has undergone the following changes:
- The text is now the title of the task
- The font is 12px
- The text overflow is hidden but allows for scroll in the event of a name too long to fit inside the chip 

<br>

### Future Considerations
*******
- The size of the scroll bar is a bit large - shrinking it would be nice
    - The classic `::-webkit-scrollbar` did not work, I am guessing because it is a MUI component