### PR TITLE
Tasklistitem style

### DIFF
--- a/client/src/components/TaskList/TaskListCard.tsx
+++ b/client/src/components/TaskList/TaskListCard.tsx
@@ -35,6 +35,12 @@ const TaskListCard = ({
         onClick={() => {
           mode == "Edit" ? removeTask(id) : {};
         }}
+        sx={{
+          transition: "background-color .5s ease",
+          "&:hover": {
+            backgroundColor: "rgba(255, 0, 17, 0.36)",
+          },
+        }}
         id={"task-list-item-delete"}
       >
         <DeleteForeverOutlinedIcon />


### PR DESCRIPTION
## Summary
In this pull request I have applied the following changes:
- The border radius glow/highlight on each ``TaskListCard`` is much softer
- The ripple color for the delete icon on each ``TaskListCard`` is now red 