### PR TITLE
changed chevron color

### DIFF
--- a/client/src/components/CustomDatePicker.tsx
+++ b/client/src/components/CustomDatePicker.tsx
@@ -17,6 +17,17 @@ const CustomDatePicker = ({ value, onChange, sxIn }: CustomDatePickerProps) => {
         label="Due Date*"
         value={value}
         onChange={onChange}
+        slotProps={{
+          previousIconButton: {
+            sx: { color: "white" },
+          },
+          nextIconButton: {
+            sx: { color: "white" },
+          },
+          switchViewIcon: {
+            sx: { color: "white" },
+          },
+        }}
         sx={{
           ...sxIn,
           "& label": {


### PR DESCRIPTION
## Summary
In a previous PR I changed the background color of the ``DatePicker`` for selecting the due date of a task to match that of the ``TaskList`` and ``CalendarContainer``. Since this is a darker color this caused the selector chevrons to become essentially invisible since they originally were black. In order for these to be seen I changed them to white.